### PR TITLE
Rename setup.bash to legacy-setup.bash

### DIFF
--- a/aws-deploy-cloudformation-iaas/defectdojo_ec2.yml
+++ b/aws-deploy-cloudformation-iaas/defectdojo_ec2.yml
@@ -227,7 +227,7 @@
 
               #Run BATCH MODE Script
               cd ${AppEBSVolumeMountPoint}/django-DefectDojo
-              ./setup.bash -b
+              ./legacy-setup.bash -b
               nohup python manage.py runserver 0.0.0.0:${DefectDojoAppPort} &
 
               #Changing Admin User password explicitly. Password reset through batch_mode is not working.


### PR DESCRIPTION

Updated defectdojo_ec2.yaml upstream repo uses legacy-setup.bash in both dev and master branches.
Upstream repo:
https://github.com/DefectDojo/django-DefectDojo

This is a hotfix to use legacy [setup.bash](https://github.com/DefectDojo/django-DefectDojo/blob/master/legacy-setup.bash)

A new setup.bash was created upstream that does not use the `-b` argument.

Will research and submit additional pull request regarding use of new setup.bash method at a later date.